### PR TITLE
Patch 1.4.1: Fix state field placeholder confusion and update Bible Bee essay upload

### DIFF
--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1725,7 +1725,11 @@ function RegisterPageContent() {
 												<FormItem>
 													<FormLabel>State</FormLabel>
 													<FormControl>
-														<Input placeholder="NJ" maxLength={2} {...field} />
+														<Input
+															placeholder="e.g., NJ"
+															maxLength={2}
+															{...field}
+														/>
 													</FormControl>
 													<FormMessage />
 												</FormItem>

--- a/src/components/gatherKids/essay-submissions.tsx
+++ b/src/components/gatherKids/essay-submissions.tsx
@@ -10,6 +10,7 @@ import {
 	CardTitle,
 	CardDescription,
 } from '@/components/ui/card';
+import { ExternalLink } from 'lucide-react';
 
 interface EssaySubmission {
 	id: string;
@@ -109,9 +110,16 @@ export function EssaySubmissions({
 									</Badge>
 									{e.status !== 'submitted' && (
 										<Button
-											onClick={() => onSubmitEssay(e.bible_bee_cycle_id)}
-											size="sm">
-											Mark Submitted
+											onClick={() =>
+												window.open(
+													'https://docs.google.com/forms/d/e/1FAIpQLSe4z-u1Tiyz403ExsRH-tV4tAO0PwI7Min4QPwBLtSrf1lQOA/viewform?usp=header',
+													'_blank'
+												)
+											}
+											size="sm"
+											variant="outline">
+											<ExternalLink className="h-4 w-4 mr-2" />
+											Upload Essay
 										</Button>
 									)}
 								</div>


### PR DESCRIPTION
## Summary

This patch release addresses two critical user experience issues that were causing confusion and workflow problems for users.

## Changes

### 1. State Field Placeholder Fix
- **Problem**: Users were confused by the state field placeholder "NJ" which appeared to be pre-filled data
- **Solution**: Changed placeholder from "NJ" to "e.g., NJ" to clearly indicate it's an example
- **Impact**: Eliminates user confusion about whether the field is already filled

### 2. Bible Bee Essay Upload Improvement  
- **Problem**: The "Mark Submitted" button was unclear about the actual essay submission process
- **Solution**: 
  - Changed button text to "Upload Essay" with external link icon
  - Button now opens Google Forms URL in new tab: https://docs.google.com/forms/d/e/1FAIpQLSe4z-u1Tiyz403ExsRH-tV4tAO0PwI7Min4QPwBLtSrf1lQOA/viewform?usp=header
  - Added ExternalLink icon to clearly indicate external navigation
- **Impact**: Provides clear path for users to actually submit their essays

## Files Modified
- `src/app/register/page.tsx` - Updated state field placeholder
- `src/components/gatherKids/essay-submissions.tsx` - Updated essay button functionality and styling

## Testing
- [x] State field shows "e.g., NJ" placeholder instead of "NJ"
- [x] Essay button shows "Upload Essay" with external link icon
- [x] Essay button opens Google Forms in new tab
- [x] Button only appears for non-submitted essays

## Deployment Notes
This is a targeted patch release focused on user experience improvements. These changes are low-risk and address specific user-reported issues.